### PR TITLE
[FE-7654] Extend uncast function to account for table-scoped columns

### DIFF
--- a/dist/mapd-crossfilter.js
+++ b/dist/mapd-crossfilter.js
@@ -16501,9 +16501,9 @@ function pruneCache(allCacheResults) {
 }
 
 function uncast(string) {
-  var matching = string.match(/^CAST\([\w_]{0,250}/);
+  var matching = string.match(/^CAST\((\w+\.)?([\w_]+)/);
   if (matching) {
-    return matching[0].split("CAST(")[1];
+    return matching[2];
   } else {
     return string;
   }

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -226,9 +226,9 @@ function pruneCache(allCacheResults) {
 }
 
 function uncast(string) {
-  const matching = string.match(/^CAST\([\w_]{0,250}/)
+  const matching = string.match(/^CAST\((\w+\.)?([\w_]+)/)
   if (matching) {
-    return matching[0].split("CAST(")[1]
+    return matching[2]
   } else {
     return string
   }

--- a/test/crossfilter.spec.js
+++ b/test/crossfilter.spec.js
@@ -1481,7 +1481,7 @@ describe("crossfilter", () => {
             .topAsync(20, 20, null)
             .then(result => {
               expect(connector.query).to.have.been.called.with(
-                "SELECT extract(month from contributions) as key0,date_trunc(month, CAST(contributions.event_date AS TIMESTAMP(0))) as key1,COUNT(*) AS val FROM contributions WHERE (CAST(contributions.event_date AS TIMESTAMP(0)) >= TIMESTAMP(0) '2006-01-01 00:00:00' AND CAST(contributions.event_date AS TIMESTAMP(0)) <= TIMESTAMP(0) '2007-01-01 00:00:00') GROUP BY key0, key1 ORDER BY val DESC LIMIT 20 OFFSET 20"
+                "SELECT extract(month from contrib_date) as key0,date_trunc(month, CAST(contributions.event_date AS TIMESTAMP(0))) as key1,COUNT(*) AS val FROM contributions WHERE (CAST(contributions.event_date AS TIMESTAMP(0)) >= TIMESTAMP(0) '2006-01-01 00:00:00' AND CAST(contributions.event_date AS TIMESTAMP(0)) <= TIMESTAMP(0) '2007-01-01 00:00:00') GROUP BY key0, key1 ORDER BY val DESC LIMIT 20 OFFSET 20"
               )
             })
         })
@@ -1962,7 +1962,7 @@ describe("crossfilter", () => {
               ])
               .all(() => {
                 expect(connector.query).to.have.been.called.with(
-                  "SELECT extract(month from contributions) as key0,COUNT(*) AS val FROM contributions GROUP BY key0 ORDER BY key0"
+                  "SELECT extract(month from contrib_date) as key0,COUNT(*) AS val FROM contributions GROUP BY key0 ORDER BY key0"
                 )
               })
           })


### PR DESCRIPTION
Due to recent changes for table-scoping columns (https://github.com/omnisci/mapd-crossfilter/pull/69, https://github.com/omnisci/mapd-crossfilter/pull/70), the `uncast()` function was broken since it depends on CAST() expressions containing an unscoped column name - this change fixes that.