### PR TITLE
[FE-7851] Sort with NULLS LAST by default for grouped queries

### DIFF
--- a/dist/mapd-crossfilter.js
+++ b/dist/mapd-crossfilter.js
@@ -18603,6 +18603,8 @@ function replaceRelative(sqlStr) {
             query += reduceArray[reduceSize - 1] + ascDescExpr;
           }
 
+          console.log('cf: hit nulls last');
+
           query += " NULLS LAST ";
 
           if (k != Infinity) {

--- a/dist/mapd-crossfilter.js
+++ b/dist/mapd-crossfilter.js
@@ -18603,6 +18603,8 @@ function replaceRelative(sqlStr) {
             query += reduceArray[reduceSize - 1] + ascDescExpr;
           }
 
+          query += " NULLS LAST ";
+
           if (k != Infinity) {
             query += " LIMIT " + k;
           }

--- a/dist/mapd-crossfilter.js
+++ b/dist/mapd-crossfilter.js
@@ -18603,9 +18603,16 @@ function replaceRelative(sqlStr) {
             query += reduceArray[reduceSize - 1] + ascDescExpr;
           }
 
-          // Add NULLS LAST to all grouped queries, to sort null measures
-          // to the end of the results regardless of sorting
-          query += " NULLS LAST ";
+          var dimensionAliases = dimArray.map(function (_, index) {
+            return "key" + index;
+          });
+          var orderingByDimension = dimensionAliases.includes(_orderExpression);
+
+          // Add NULLS LAST to all grouped queries by default, unless ordering by a dimension,
+          // to sort null measures to the end of the results regardless of sorting
+          if (!orderingByDimension) {
+            query += " NULLS LAST";
+          }
 
           if (k != Infinity) {
             query += " LIMIT " + k;

--- a/dist/mapd-crossfilter.js
+++ b/dist/mapd-crossfilter.js
@@ -18603,8 +18603,8 @@ function replaceRelative(sqlStr) {
             query += reduceArray[reduceSize - 1] + ascDescExpr;
           }
 
-          console.log('cf: hit nulls last');
-
+          // Add NULLS LAST to all grouped queries, to sort null measures
+          // to the end of the results regardless of sorting
           query += " NULLS LAST ";
 
           if (k != Infinity) {

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -2318,6 +2318,8 @@ export function replaceRelative(sqlStr) {
             query += reduceArray[reduceSize - 1] + ascDescExpr
           }
 
+          query += " NULLS LAST "
+
           if (k != Infinity) {
             query += " LIMIT " + k
           }

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -2318,9 +2318,14 @@ export function replaceRelative(sqlStr) {
             query += reduceArray[reduceSize - 1] + ascDescExpr
           }
 
-          // Add NULLS LAST to all grouped queries, to sort null measures
-          // to the end of the results regardless of sorting
-          query += " NULLS LAST"
+          const dimensionAliases = dimArray.map((_, index) => `key${index}`)
+          const orderingByDimension = dimensionAliases.includes(_orderExpression)
+
+          // Add NULLS LAST to all grouped queries by default, unless ordering by a dimension,
+          // to sort null measures to the end of the results regardless of sorting
+          if (!orderingByDimension) {
+            query += " NULLS LAST"
+          }
 
           if (k != Infinity) {
             query += " LIMIT " + k

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -2318,6 +2318,8 @@ export function replaceRelative(sqlStr) {
             query += reduceArray[reduceSize - 1] + ascDescExpr
           }
 
+          console.log('cf: hit nulls last')
+
           query += " NULLS LAST "
 
           if (k != Infinity) {

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -2318,9 +2318,9 @@ export function replaceRelative(sqlStr) {
             query += reduceArray[reduceSize - 1] + ascDescExpr
           }
 
-          console.log('cf: hit nulls last')
-
-          query += " NULLS LAST "
+          // Add NULLS LAST to all grouped queries, to sort null measures
+          // to the end of the results regardless of sorting
+          query += " NULLS LAST"
 
           if (k != Infinity) {
             query += " LIMIT " + k

--- a/test/crossfilter.spec.js
+++ b/test/crossfilter.spec.js
@@ -1249,7 +1249,7 @@ describe("crossfilter", () => {
           ]
           group.reduce(expressions)
           expect(group.top(1)).to.eq(
-            "SELECT bargle as key0,COUNT(*) AS count_all,COUNT(*) AS count_star FROM table1 GROUP BY key0 ORDER BY count_all DESC,count_star DESC LIMIT 1"
+            "SELECT bargle as key0,COUNT(*) AS count_all,COUNT(*) AS count_star FROM table1 GROUP BY key0 ORDER BY count_all DESC,count_star DESC NULLS LAST LIMIT 1"
           )
         })
         it("sets composite reduceExpression", () => {
@@ -1263,7 +1263,7 @@ describe("crossfilter", () => {
           ]
           group.reduce(expressions)
           expect(group.top(1)).to.eq(
-            "SELECT bargle as key0,AVG(arrdelay+depdelay) AS avg_delays FROM table1 GROUP BY key0 ORDER BY avg_delays DESC LIMIT 1"
+            "SELECT bargle as key0,AVG(arrdelay+depdelay) AS avg_delays FROM table1 GROUP BY key0 ORDER BY avg_delays DESC NULLS LAST LIMIT 1"
           )
         })
       })
@@ -1297,7 +1297,7 @@ describe("crossfilter", () => {
         })
         it("constructs query", () => {
           expect(group.writeTopQuery(1, 2)).to.eq(
-            "SELECT users.id as key0,COUNT(*) AS val FROM users GROUP BY key0 ORDER BY val DESC LIMIT 1 OFFSET 2"
+            "SELECT users.id as key0,COUNT(*) AS val FROM users GROUP BY key0 ORDER BY val DESC NULLS LAST LIMIT 1 OFFSET 2"
           )
         })
         it("orders by orderExpression if any", () => {
@@ -1323,7 +1323,7 @@ describe("crossfilter", () => {
             { expression: "cty", agg_mode: "COUNT", name: "cnt_cty" }
           ])
           expect(group.writeTopQuery(1)).to.eq(
-            "SELECT users.id as key0,MAX(age) AS max_age,AVG(lbs) AS avg_lbs,COUNT(cty) AS cnt_cty FROM users WHERE age IS NOT NULL AND lbs IS NOT NULL AND cty IS NOT NULL GROUP BY key0 ORDER BY max_age DESC,avg_lbs DESC,cnt_cty DESC LIMIT 1"
+            "SELECT users.id as key0,MAX(age) AS max_age,AVG(lbs) AS avg_lbs,COUNT(cty) AS cnt_cty FROM users WHERE age IS NOT NULL AND lbs IS NOT NULL AND cty IS NOT NULL GROUP BY key0 ORDER BY max_age DESC,avg_lbs DESC,cnt_cty DESC NULLS LAST LIMIT 1"
           )
         })
         it("works with reduce expressions including COUNT(*)", () => {
@@ -1333,17 +1333,17 @@ describe("crossfilter", () => {
             { expression: "*", agg_mode: "COUNT", name: "cnt_bad" }
           ])
           expect(group.writeTopQuery(1)).to.eq(
-            "SELECT users.id as key0,AVG(lbs) AS avg_lbs,COUNT(*) AS cnt_cty,COUNT(*) AS cnt_bad FROM users WHERE lbs IS NOT NULL GROUP BY key0 ORDER BY avg_lbs DESC,cnt_cty DESC,cnt_bad DESC LIMIT 1"
+            "SELECT users.id as key0,AVG(lbs) AS avg_lbs,COUNT(*) AS cnt_cty,COUNT(*) AS cnt_bad FROM users WHERE lbs IS NOT NULL GROUP BY key0 ORDER BY avg_lbs DESC,cnt_cty DESC,cnt_bad DESC NULLS LAST LIMIT 1"
           )
         })
         it("appropriately handles render queries with rowid dimension", () => {
           var dim = crossfilter.dimension(["bargle", "rowid"])
           var group = dim.group()
           expect(group.writeTopQuery(1, 2)).to.eql(
-            "SELECT users.bargle as key0,users.rowid as key1,COUNT(*) AS val FROM users GROUP BY key0, key1 ORDER BY val DESC LIMIT 1 OFFSET 2"
+            "SELECT users.bargle as key0,users.rowid as key1,COUNT(*) AS val FROM users GROUP BY key0, key1 ORDER BY val DESC NULLS LAST LIMIT 1 OFFSET 2"
           )
           expect(group.writeTopQuery(1, 2, false, true)).to.eql(
-            "SELECT users.bargle as key0,users.rowid,COUNT(*) AS val FROM users GROUP BY key0, users.rowid ORDER BY val DESC LIMIT 1 OFFSET 2"
+            "SELECT users.bargle as key0,users.rowid,COUNT(*) AS val FROM users GROUP BY key0, users.rowid ORDER BY val DESC NULLS LAST LIMIT 1 OFFSET 2"
           )
         })
       })
@@ -1360,7 +1360,7 @@ describe("crossfilter", () => {
         })
         it("constructs and runs query", () => {
           expect(group.top(1, 2)).to.eq(
-            "SELECT users.id as key0,COUNT(*) AS val FROM users GROUP BY key0 ORDER BY val DESC LIMIT 1 OFFSET 2"
+            "SELECT users.id as key0,COUNT(*) AS val FROM users GROUP BY key0 ORDER BY val DESC NULLS LAST LIMIT 1 OFFSET 2"
           )
         })
         it("orders by orderExpression if any", () => {
@@ -1386,7 +1386,7 @@ describe("crossfilter", () => {
             { expression: "cty", agg_mode: "COUNT", name: "cnt_cty" }
           ])
           expect(group.top(1)).to.eq(
-            "SELECT users.id as key0,MAX(age) AS max_age,AVG(lbs) AS avg_lbs,COUNT(cty) AS cnt_cty FROM users WHERE age IS NOT NULL AND lbs IS NOT NULL AND cty IS NOT NULL GROUP BY key0 ORDER BY max_age DESC,avg_lbs DESC,cnt_cty DESC LIMIT 1"
+            "SELECT users.id as key0,MAX(age) AS max_age,AVG(lbs) AS avg_lbs,COUNT(cty) AS cnt_cty FROM users WHERE age IS NOT NULL AND lbs IS NOT NULL AND cty IS NOT NULL GROUP BY key0 ORDER BY max_age DESC,avg_lbs DESC,cnt_cty DESC NULLS LAST LIMIT 1"
           )
         })
         it("works with reduce expressions including COUNT(*)", () => {
@@ -1396,7 +1396,7 @@ describe("crossfilter", () => {
             { expression: "*", agg_mode: "COUNT", name: "cnt_bad" }
           ])
           expect(group.top(1)).to.eq(
-            "SELECT users.id as key0,AVG(lbs) AS avg_lbs,COUNT(*) AS cnt_cty,COUNT(*) AS cnt_bad FROM users WHERE lbs IS NOT NULL GROUP BY key0 ORDER BY avg_lbs DESC,cnt_cty DESC,cnt_bad DESC LIMIT 1"
+            "SELECT users.id as key0,AVG(lbs) AS avg_lbs,COUNT(*) AS cnt_cty,COUNT(*) AS cnt_bad FROM users WHERE lbs IS NOT NULL GROUP BY key0 ORDER BY avg_lbs DESC,cnt_cty DESC,cnt_bad DESC NULLS LAST LIMIT 1"
           )
         })
         it("can return sync results", function() {
@@ -1470,7 +1470,7 @@ describe("crossfilter", () => {
             .topAsync(20, 20, null)
             .then(result => {
               expect(connector.queryAsync).to.have.been.called.with(
-                "SELECT date_trunc(month, CAST(contributions.contrib_date AS TIMESTAMP(0))) as key0,date_trunc(month, CAST(contributions.event_date AS TIMESTAMP(0))) as key1,COUNT(*) AS val FROM contributions WHERE (CAST(contributions.contrib_date AS TIMESTAMP(0)) >= TIMESTAMP(0) '2006-01-01 00:00:00' AND CAST(contributions.contrib_date AS TIMESTAMP(0)) <= TIMESTAMP(0) '2007-01-01 00:00:00') AND (CAST(contributions.event_date AS TIMESTAMP(0)) >= TIMESTAMP(0) '2006-01-01 00:00:00' AND CAST(contributions.event_date AS TIMESTAMP(0)) <= TIMESTAMP(0) '2007-01-01 00:00:00') GROUP BY key0, key1 ORDER BY val DESC LIMIT 20 OFFSET 20"
+                "SELECT date_trunc(month, CAST(contributions.contrib_date AS TIMESTAMP(0))) as key0,date_trunc(month, CAST(contributions.event_date AS TIMESTAMP(0))) as key1,COUNT(*) AS val FROM contributions WHERE (CAST(contributions.contrib_date AS TIMESTAMP(0)) >= TIMESTAMP(0) '2006-01-01 00:00:00' AND CAST(contributions.contrib_date AS TIMESTAMP(0)) <= TIMESTAMP(0) '2007-01-01 00:00:00') AND (CAST(contributions.event_date AS TIMESTAMP(0)) >= TIMESTAMP(0) '2006-01-01 00:00:00' AND CAST(contributions.event_date AS TIMESTAMP(0)) <= TIMESTAMP(0) '2007-01-01 00:00:00') GROUP BY key0, key1 ORDER BY val DESC NULLS LAST LIMIT 20 OFFSET 20"
               )
             })
         })
@@ -1499,7 +1499,7 @@ describe("crossfilter", () => {
             .topAsync(20, 20, null)
             .then(result => {
               expect(connector.queryAsync).to.have.been.called.with(
-                "SELECT extract(month from contrib_date) as key0,date_trunc(month, CAST(contributions.event_date AS TIMESTAMP(0))) as key1,COUNT(*) AS val FROM contributions WHERE (CAST(contributions.event_date AS TIMESTAMP(0)) >= TIMESTAMP(0) '2006-01-01 00:00:00' AND CAST(contributions.event_date AS TIMESTAMP(0)) <= TIMESTAMP(0) '2007-01-01 00:00:00') GROUP BY key0, key1 ORDER BY val DESC LIMIT 20 OFFSET 20"
+                "SELECT extract(month from contrib_date) as key0,date_trunc(month, CAST(contributions.event_date AS TIMESTAMP(0))) as key1,COUNT(*) AS val FROM contributions WHERE (CAST(contributions.event_date AS TIMESTAMP(0)) >= TIMESTAMP(0) '2006-01-01 00:00:00' AND CAST(contributions.event_date AS TIMESTAMP(0)) <= TIMESTAMP(0) '2007-01-01 00:00:00') GROUP BY key0, key1 ORDER BY val DESC NULLS LAST LIMIT 20 OFFSET 20"
               )
             })
         })
@@ -1536,7 +1536,7 @@ describe("crossfilter", () => {
         })
         it("constructs query", () => {
           expect(group.writeBottomQuery(1, 2)).to.eq(
-            "SELECT users.id as key0,COUNT(*) AS val FROM users GROUP BY key0 ORDER BY val LIMIT 1 OFFSET 2"
+            "SELECT users.id as key0,COUNT(*) AS val FROM users GROUP BY key0 ORDER BY val NULLS LAST LIMIT 1 OFFSET 2"
           )
         })
         it("orders by orderExpression if any", () => {
@@ -1561,17 +1561,17 @@ describe("crossfilter", () => {
             { expression: "rx", agg_mode: "SUM", name: "sum_rx" }
           ])
           expect(group.writeBottomQuery(1)).to.eq(
-            "SELECT users.id as key0,MIN(id) AS min_id,SUM(rx) AS sum_rx FROM users WHERE id IS NOT NULL AND rx IS NOT NULL GROUP BY key0 ORDER BY min_id,sum_rx LIMIT 1"
+            "SELECT users.id as key0,MIN(id) AS min_id,SUM(rx) AS sum_rx FROM users WHERE id IS NOT NULL AND rx IS NOT NULL GROUP BY key0 ORDER BY min_id,sum_rx NULLS LAST LIMIT 1"
           )
         })
         it("appropriately handles render queries with rowid dimension", () => {
           var dim = crossfilter.dimension(["bargle", "rowid"])
           var group = dim.group()
           expect(group.writeBottomQuery(1, 2)).to.eql(
-            "SELECT users.bargle as key0,users.rowid as key1,COUNT(*) AS val FROM users GROUP BY key0, key1 ORDER BY val LIMIT 1 OFFSET 2"
+            "SELECT users.bargle as key0,users.rowid as key1,COUNT(*) AS val FROM users GROUP BY key0, key1 ORDER BY val NULLS LAST LIMIT 1 OFFSET 2"
           )
           expect(group.writeBottomQuery(1, 2, false, true)).to.eql(
-            "SELECT users.bargle as key0,users.rowid,COUNT(*) AS val FROM users GROUP BY key0, users.rowid ORDER BY val LIMIT 1 OFFSET 2"
+            "SELECT users.bargle as key0,users.rowid,COUNT(*) AS val FROM users GROUP BY key0, users.rowid ORDER BY val NULLS LAST LIMIT 1 OFFSET 2"
           )
         })
       })
@@ -1587,7 +1587,7 @@ describe("crossfilter", () => {
         })
         it("constructs and runs query", () => {
           expect(group.bottom(1, 2)).to.eq(
-            "SELECT users.id as key0,COUNT(*) AS val FROM users GROUP BY key0 ORDER BY val LIMIT 1 OFFSET 2"
+            "SELECT users.id as key0,COUNT(*) AS val FROM users GROUP BY key0 ORDER BY val NULLS LAST LIMIT 1 OFFSET 2"
           )
         })
         it("orders by orderExpression if any", () => {
@@ -1612,7 +1612,7 @@ describe("crossfilter", () => {
             { expression: "rx", agg_mode: "SUM", name: "sum_rx" }
           ])
           expect(group.bottom(1)).to.eq(
-            "SELECT users.id as key0,MIN(id) AS min_id,SUM(rx) AS sum_rx FROM users WHERE id IS NOT NULL AND rx IS NOT NULL GROUP BY key0 ORDER BY min_id,sum_rx LIMIT 1"
+            "SELECT users.id as key0,MIN(id) AS min_id,SUM(rx) AS sum_rx FROM users WHERE id IS NOT NULL AND rx IS NOT NULL GROUP BY key0 ORDER BY min_id,sum_rx NULLS LAST LIMIT 1"
           )
         })
         it("can return sync results", function() {
@@ -2057,13 +2057,13 @@ describe("crossfilter", () => {
         it("prevents nulls for non-COUNT agg modes", () => {
           group.reduceAvg("age")
           expect(group.top(1)).to.eq(
-            "SELECT bargle as key0,AVG(age) AS val FROM table1 WHERE age IS NOT NULL GROUP BY key0 ORDER BY val DESC LIMIT 1"
+            "SELECT bargle as key0,AVG(age) AS val FROM table1 WHERE age IS NOT NULL GROUP BY key0 ORDER BY val DESC NULLS LAST LIMIT 1"
           )
         })
         it("does null COUNT measures", () => {
           group.reduceCount("lbs")
           expect(group.top(1)).to.eq(
-            "SELECT bargle as key0,COUNT(lbs) AS val FROM table1 WHERE lbs IS NOT NULL GROUP BY key0 ORDER BY val DESC LIMIT 1"
+            "SELECT bargle as key0,COUNT(lbs) AS val FROM table1 WHERE lbs IS NOT NULL GROUP BY key0 ORDER BY val DESC NULLS LAST LIMIT 1"
           )
         })
         xit("prevents no nulls when no agg mode", () => {

--- a/test/crossfilter.spec.js
+++ b/test/crossfilter.spec.js
@@ -1307,6 +1307,10 @@ describe("crossfilter", () => {
         it("orders by groupExpression if no orderExpression", () => {
           expect(group.writeTopQuery()).to.include("ORDER BY val")
         })
+        it("does not include NULLS LAST if orderExpression is a dimension key alias", () => {
+          group.order("key0")
+          expect(group.writeTopQuery()).to.not.include("NULLS LAST")
+        })
         it("limits results if k < Infinity", () => {
           expect(group.writeTopQuery(10)).to.include("LIMIT 10")
         })


### PR DESCRIPTION
Add NULLS LAST to grouped queries by default, in order to sort all null measure values to the end of the results.