### PR TITLE
[FE-8853] Use higher precision when filtering date ranges

### DIFF
--- a/test/crossfilter.spec.js
+++ b/test/crossfilter.spec.js
@@ -1479,7 +1479,7 @@ describe("crossfilter", () => {
             .topAsync(20, 20, null)
             .then(result => {
               expect(connector.queryAsync).to.have.been.called.with(
-                "SELECT date_trunc(month, CAST(contributions.contrib_date AS TIMESTAMP(3))) as key0,date_trunc(month, CAST(contributions.event_date AS TIMESTAMP(3))) as key1,COUNT(*) AS val FROM contributions WHERE (CAST(contributions.contrib_date AS TIMESTAMP(3)) >= TIMESTAMP(3) '2006-01-01 00:00:00.000' AND CAST(contributions.contrib_date AS TIMESTAMP(3)) <= TIMESTAMP(3) '2007-01-01 00:00:00.000') AND (CAST(contributions.event_date AS TIMESTAMP(3)) >= TIMESTAMP(3) '2006-01-01 00:00:00.000' AND CAST(contributions.event_date AS TIMESTAMP(3)) <= TIMESTAMP(3) '2007-01-01 00:00:00.000') GROUP BY key0, key1 ORDER BY val DESC NULLS LAST LIMIT 20 OFFSET 20"
+                "SELECT date_trunc(month, CAST(contributions.contrib_date AS TIMESTAMP(3))) as key0,date_trunc(month, CAST(contributions.event_date AS TIMESTAMP(3))) as key1,COUNT(*) AS val FROM contributions WHERE (CAST(contributions.contrib_date AS TIMESTAMP(3)) >= TIMESTAMP(9) '2006-01-01 00:00:00.000000000' AND CAST(contributions.contrib_date AS TIMESTAMP(3)) <= TIMESTAMP(9) '2007-01-01 00:00:00.000999999') AND (CAST(contributions.event_date AS TIMESTAMP(3)) >= TIMESTAMP(9) '2006-01-01 00:00:00.000000000' AND CAST(contributions.event_date AS TIMESTAMP(3)) <= TIMESTAMP(9) '2007-01-01 00:00:00.000999999') GROUP BY key0, key1 ORDER BY val DESC NULLS LAST LIMIT 20 OFFSET 20"
               )
             })
         })
@@ -1508,7 +1508,7 @@ describe("crossfilter", () => {
             .topAsync(20, 20, null)
             .then(result => {
               expect(connector.queryAsync).to.have.been.called.with(
-                "SELECT extract(month from contrib_date) as key0,date_trunc(month, CAST(contributions.event_date AS TIMESTAMP(3))) as key1,COUNT(*) AS val FROM contributions WHERE (CAST(contributions.event_date AS TIMESTAMP(3)) >= TIMESTAMP(3) '2006-01-01 00:00:00.000' AND CAST(contributions.event_date AS TIMESTAMP(3)) <= TIMESTAMP(3) '2007-01-01 00:00:00.000') GROUP BY key0, key1 ORDER BY val DESC NULLS LAST LIMIT 20 OFFSET 20"
+                "SELECT extract(month from contrib_date) as key0,date_trunc(month, CAST(contributions.event_date AS TIMESTAMP(3))) as key1,COUNT(*) AS val FROM contributions WHERE (CAST(contributions.event_date AS TIMESTAMP(3)) >= TIMESTAMP(9) '2006-01-01 00:00:00.000000000' AND CAST(contributions.event_date AS TIMESTAMP(3)) <= TIMESTAMP(9) '2007-01-01 00:00:00.000999999') GROUP BY key0, key1 ORDER BY val DESC NULLS LAST LIMIT 20 OFFSET 20"
               )
             })
         })
@@ -1984,7 +1984,7 @@ describe("crossfilter", () => {
               ])
               .all(() => {
                 expect(connector.queryAsync).to.have.been.called.with(
-                  "SELECT date_trunc(month, CAST(contributions.contrib_date AS TIMESTAMP(3))) as key0,COUNT(*) AS val FROM contributions WHERE (CAST(contributions.contrib_date AS TIMESTAMP(3)) >= TIMESTAMP(3) '2006-01-01 00:00:00.000' AND CAST(contributions.contrib_date AS TIMESTAMP(3)) <= TIMESTAMP(3) '2007-01-01 00:00:00.000') GROUP BY key0 ORDER BY key0"
+                  "SELECT date_trunc(month, CAST(contributions.contrib_date AS TIMESTAMP(3))) as key0,COUNT(*) AS val FROM contributions WHERE (CAST(contributions.contrib_date AS TIMESTAMP(3)) >= TIMESTAMP(9) '2006-01-01 00:00:00.000000000' AND CAST(contributions.contrib_date AS TIMESTAMP(3)) <= TIMESTAMP(9) '2007-01-01 00:00:00.000999999') GROUP BY key0 ORDER BY key0"
                 )
               })
           })


### PR DESCRIPTION
Table chart (and likely other charts) weren't crossfiltering appropriately on high precision timestamps that had greater precision than milliseconds. 

For example, when you'd filter on a row in a table chart that involved greater-than-millisecond precision, a duplicate table chart would show zero results. This is because the WHERE clause generated to filter other tables looked like this:

```SQL
AND ((data_types_basic20.col_ts9_1 >= TIMESTAMP(3) '2019-12-25 23:45:20.977'
        AND data_types_basic20.col_ts9_1 <= TIMESTAMP(3) '2019-12-25 23:45:20.977'))
```

 A condition that would only be met if a result's `col_ts9_1` was exactly equal to `2019-12-25 23:45:20.977`, or essentially, equal to `2019-12-25 23:45:20.977000000`

We need to increase the precision when querying date ranges to `TIMESTAMP(9)`, and query the lower and upper bounds of a millisecond value. Effectively making the above query this:

```SQL
AND ((data_types_basic20.col_ts9_1 >= TIMESTAMP(9) '2019-12-25 23:45:20.977000000'
        AND data_types_basic20.col_ts9_1 <= TIMESTAMP(9) '2019-12-25 23:45:20.977999999'))
```


