### PR TITLE
[FE-8908] Fix `NULLS LAST` usage

### DIFF
--- a/dist/mapd-crossfilter.js
+++ b/dist/mapd-crossfilter.js
@@ -18930,27 +18930,33 @@ function replaceRelative(sqlStr) {
             return "";
           }
 
-          query += " ORDER BY ";
-          if (_orderExpression) {
-            query += _orderExpression + ascDescExpr;
-          } else {
-            var reduceArray = reduceVars.split(",");
-            var reduceSize = reduceArray.length;
-            for (var r = 0; r < reduceSize - 1; r++) {
-              query += reduceArray[r] + ascDescExpr + ",";
-            }
-            query += reduceArray[reduceSize - 1] + ascDescExpr;
-          }
-
           var dimensionAliases = dimArray.map(function (_, index) {
             return "key" + index;
           });
           var orderingByDimension = dimensionAliases.includes(_orderExpression);
 
-          // Add NULLS LAST to all grouped queries by default, unless ordering by a dimension,
-          // to sort null measures to the end of the results regardless of sorting
-          if (!orderingByDimension) {
-            query += " NULLS LAST";
+          query += " ORDER BY ";
+          if (_orderExpression) {
+            query += _orderExpression + ascDescExpr;
+            // Add NULLS LAST to all grouped queries by default, unless ordering by a dimension,
+            // to sort null measures to the end of the results regardless of sorting
+            if (!orderingByDimension) {
+              query += " NULLS LAST";
+            }
+          } else {
+            var reduceArray = reduceVars.split(",");
+            var reduceSize = reduceArray.length;
+            for (var r = 0; r < reduceSize - 1; r++) {
+              query += reduceArray[r] + ascDescExpr;
+              if (!orderingByDimension) {
+                query += " NULLS LAST";
+              }
+              query += ",";
+            }
+            query += reduceArray[reduceSize - 1] + ascDescExpr;
+            if (!orderingByDimension) {
+              query += " NULLS LAST";
+            }
           }
 
           if (k != Infinity) {

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -1626,6 +1626,7 @@ export function replaceRelative(sqlStr) {
       }
 
       function topAsync(k, offset, renderSpec) {
+        debugger
         return new Promise((resolve, reject) => {
           top(k, offset, renderSpec, (error, result) => {
             if (error) {
@@ -2361,27 +2362,33 @@ export function replaceRelative(sqlStr) {
             return ""
           }
 
-          query += " ORDER BY "
-          if (_orderExpression) {
-            query += _orderExpression + ascDescExpr
-          } else {
-            var reduceArray = reduceVars.split(",")
-            var reduceSize = reduceArray.length
-            for (var r = 0; r < reduceSize - 1; r++) {
-              query += reduceArray[r] + ascDescExpr + ","
-            }
-            query += reduceArray[reduceSize - 1] + ascDescExpr
-          }
-
           const dimensionAliases = dimArray.map((_, index) => `key${index}`)
           const orderingByDimension = dimensionAliases.includes(
             _orderExpression
           )
 
-          // Add NULLS LAST to all grouped queries by default, unless ordering by a dimension,
-          // to sort null measures to the end of the results regardless of sorting
-          if (!orderingByDimension) {
-            query += " NULLS LAST"
+          query += " ORDER BY "
+          if (_orderExpression) {
+            query += _orderExpression + ascDescExpr
+            // Add NULLS LAST to all grouped queries by default, unless ordering by a dimension,
+            // to sort null measures to the end of the results regardless of sorting
+            if (!orderingByDimension) {
+              query += " NULLS LAST"
+            }
+          } else {
+            var reduceArray = reduceVars.split(",")
+            var reduceSize = reduceArray.length
+            for (var r = 0; r < reduceSize - 1; r++) {
+              query += reduceArray[r] + ascDescExpr
+              if (!orderingByDimension) {
+                query += " NULLS LAST"
+              }
+              query += ","
+            }
+            query += reduceArray[reduceSize - 1] + ascDescExpr
+            if (!orderingByDimension) {
+              query += " NULLS LAST"
+            }
           }
 
           if (k != Infinity) {

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -1626,7 +1626,6 @@ export function replaceRelative(sqlStr) {
       }
 
       function topAsync(k, offset, renderSpec) {
-        debugger
         return new Promise((resolve, reject) => {
           top(k, offset, renderSpec, (error, result) => {
             if (error) {

--- a/test/crossfilter.spec.js
+++ b/test/crossfilter.spec.js
@@ -1249,7 +1249,7 @@ describe("crossfilter", () => {
           ]
           group.reduce(expressions)
           expect(group.top(1)).to.eq(
-            "SELECT bargle AS key0,COUNT(*) AS count_all,COUNT(*) AS count_star FROM table1 GROUP BY key0 ORDER BY count_all DESC,count_star DESC NULLS LAST LIMIT 1"
+            "SELECT bargle AS key0,COUNT(*) AS count_all,COUNT(*) AS count_star FROM table1 GROUP BY key0 ORDER BY count_all DESC NULLS LAST,count_star DESC NULLS LAST LIMIT 1"
           )
         })
         it("sets composite reduceExpression", () => {
@@ -1330,7 +1330,7 @@ describe("crossfilter", () => {
             { expression: "cty", agg_mode: "COUNT", name: "cnt_cty" }
           ])
           expect(group.writeTopQuery(1)).to.eq(
-            "SELECT users.id AS key0,MAX(age) AS max_age,AVG(lbs) AS avg_lbs,COUNT(cty) AS cnt_cty FROM users WHERE age IS NOT NULL AND lbs IS NOT NULL AND cty IS NOT NULL GROUP BY key0 ORDER BY max_age DESC,avg_lbs DESC,cnt_cty DESC NULLS LAST LIMIT 1"
+            "SELECT users.id AS key0,MAX(age) AS max_age,AVG(lbs) AS avg_lbs,COUNT(cty) AS cnt_cty FROM users WHERE age IS NOT NULL AND lbs IS NOT NULL AND cty IS NOT NULL GROUP BY key0 ORDER BY max_age DESC NULLS LAST,avg_lbs DESC NULLS LAST,cnt_cty DESC NULLS LAST LIMIT 1"
           )
         })
         it("works with reduce expressions including COUNT(*)", () => {
@@ -1340,7 +1340,7 @@ describe("crossfilter", () => {
             { expression: "*", agg_mode: "COUNT", name: "cnt_bad" }
           ])
           expect(group.writeTopQuery(1)).to.eq(
-            "SELECT users.id AS key0,AVG(lbs) AS avg_lbs,COUNT(*) AS cnt_cty,COUNT(*) AS cnt_bad FROM users WHERE lbs IS NOT NULL GROUP BY key0 ORDER BY avg_lbs DESC,cnt_cty DESC,cnt_bad DESC NULLS LAST LIMIT 1"
+            "SELECT users.id AS key0,AVG(lbs) AS avg_lbs,COUNT(*) AS cnt_cty,COUNT(*) AS cnt_bad FROM users WHERE lbs IS NOT NULL GROUP BY key0 ORDER BY avg_lbs DESC NULLS LAST,cnt_cty DESC NULLS LAST,cnt_bad DESC NULLS LAST LIMIT 1"
           )
         })
         it("appropriately handles render queries with rowid dimension", () => {
@@ -1393,7 +1393,7 @@ describe("crossfilter", () => {
             { expression: "cty", agg_mode: "COUNT", name: "cnt_cty" }
           ])
           expect(group.top(1)).to.eq(
-            "SELECT users.id AS key0,MAX(age) AS max_age,AVG(lbs) AS avg_lbs,COUNT(cty) AS cnt_cty FROM users WHERE age IS NOT NULL AND lbs IS NOT NULL AND cty IS NOT NULL GROUP BY key0 ORDER BY max_age DESC,avg_lbs DESC,cnt_cty DESC NULLS LAST LIMIT 1"
+            "SELECT users.id AS key0,MAX(age) AS max_age,AVG(lbs) AS avg_lbs,COUNT(cty) AS cnt_cty FROM users WHERE age IS NOT NULL AND lbs IS NOT NULL AND cty IS NOT NULL GROUP BY key0 ORDER BY max_age DESC NULLS LAST,avg_lbs DESC NULLS LAST,cnt_cty DESC NULLS LAST LIMIT 1"
           )
         })
         it("works with reduce expressions including COUNT(*)", () => {
@@ -1403,7 +1403,7 @@ describe("crossfilter", () => {
             { expression: "*", agg_mode: "COUNT", name: "cnt_bad" }
           ])
           expect(group.top(1)).to.eq(
-            "SELECT users.id AS key0,AVG(lbs) AS avg_lbs,COUNT(*) AS cnt_cty,COUNT(*) AS cnt_bad FROM users WHERE lbs IS NOT NULL GROUP BY key0 ORDER BY avg_lbs DESC,cnt_cty DESC,cnt_bad DESC NULLS LAST LIMIT 1"
+            "SELECT users.id AS key0,AVG(lbs) AS avg_lbs,COUNT(*) AS cnt_cty,COUNT(*) AS cnt_bad FROM users WHERE lbs IS NOT NULL GROUP BY key0 ORDER BY avg_lbs DESC NULLS LAST,cnt_cty DESC NULLS LAST,cnt_bad DESC NULLS LAST LIMIT 1"
           )
         })
         it("can return sync results", function() {
@@ -1570,7 +1570,7 @@ describe("crossfilter", () => {
             { expression: "rx", agg_mode: "SUM", name: "sum_rx" }
           ])
           expect(group.writeBottomQuery(1)).to.eq(
-            "SELECT users.id AS key0,MIN(id) AS min_id,SUM(rx) AS sum_rx FROM users WHERE id IS NOT NULL AND rx IS NOT NULL GROUP BY key0 ORDER BY min_id,sum_rx NULLS LAST LIMIT 1"
+            "SELECT users.id AS key0,MIN(id) AS min_id,SUM(rx) AS sum_rx FROM users WHERE id IS NOT NULL AND rx IS NOT NULL GROUP BY key0 ORDER BY min_id NULLS LAST,sum_rx NULLS LAST LIMIT 1"
           )
         })
         it("appropriately handles render queries with rowid dimension", () => {
@@ -1621,7 +1621,7 @@ describe("crossfilter", () => {
             { expression: "rx", agg_mode: "SUM", name: "sum_rx" }
           ])
           expect(group.bottom(1)).to.eq(
-            "SELECT users.id AS key0,MIN(id) AS min_id,SUM(rx) AS sum_rx FROM users WHERE id IS NOT NULL AND rx IS NOT NULL GROUP BY key0 ORDER BY min_id,sum_rx NULLS LAST LIMIT 1"
+            "SELECT users.id AS key0,MIN(id) AS min_id,SUM(rx) AS sum_rx FROM users WHERE id IS NOT NULL AND rx IS NOT NULL GROUP BY key0 ORDER BY min_id NULLS LAST,sum_rx NULLS LAST LIMIT 1"
           )
         })
         it("can return sync results", function() {


### PR DESCRIPTION
In an `ORDER BY...` statement in omnisql, `NULLS LAST` needs to be suffixed to every ordering expression. For example, `... ORDER BY foo DESC NULLS LAST, bar DESC NULLS LAST`. However, currently, crossfilter only adds `NULLS LAST` to the end of the final ordering expression.

This was causing errors where some charts were seeing incorrect rendering because the null data was coming up first. This commit fixes that to properly add `NULLS LAST` to every ordering expression.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Fixes FE-8908

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
