### PR TITLE
[FE-9285] Fix global filter toggle not always applying to queries

### DIFF
--- a/dist/mapd-crossfilter.js
+++ b/dist/mapd-crossfilter.js
@@ -18249,7 +18249,15 @@ function replaceRelative(sqlStr) {
         var filterQuery = "";
         var nonNullFilterCount = 0;
         var allFilters = filters.concat(globalFilters);
-        var allDisabledFilters = disabledFilters.concat(disabledGlobalFilters);
+
+        var denseDisabledFilters = Array.from(filters, function (_, index) {
+          return Boolean(disabledFilters[index]);
+        });
+        var denseDisabledGlobalFilters = Array.from(globalFilters, function (_, index) {
+          return Boolean(disabledGlobalFilters[index]);
+        });
+
+        var allDisabledFilters = denseDisabledFilters.concat(denseDisabledGlobalFilters);
 
         // we observe this dimensions filter
         for (var i = 0; i < allFilters.length; i++) {
@@ -18504,7 +18512,15 @@ function replaceRelative(sqlStr) {
           var filterQuery = "";
           var nonNullFilterCount = 0;
           var allFilters = filters.concat(globalFilters);
-          var allDisabledFilters = disabledFilters.concat(disabledGlobalFilters);
+
+          var denseDisabledFilters = Array.from(filters, function (_, index) {
+            return Boolean(disabledFilters[index]);
+          });
+          var denseDisabledGlobalFilters = Array.from(globalFilters, function (_, index) {
+            return Boolean(disabledGlobalFilters[index]);
+          });
+
+          var allDisabledFilters = denseDisabledFilters.concat(denseDisabledGlobalFilters);
 
           // we do not observe this dimensions filter
           for (var i = 0; i < allFilters.length; i++) {

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -720,7 +720,12 @@ export function replaceRelative(sqlStr) {
       var filterString = ""
       var firstElem = true
       filters.forEach(function(value, index) {
-        if (!disabledFilters[index] && value != null && value != "" && index !== dimIgnoreIndex) {
+        if (
+          !disabledFilters[index] &&
+          value != null &&
+          value != "" &&
+          index !== dimIgnoreIndex
+        ) {
           if (!firstElem) {
             filterString += " AND "
           }
@@ -1549,7 +1554,19 @@ export function replaceRelative(sqlStr) {
         var filterQuery = ""
         var nonNullFilterCount = 0
         var allFilters = filters.concat(globalFilters)
-        var allDisabledFilters = disabledFilters.concat(disabledGlobalFilters)
+
+        // Fill in dense arrays to match the filter list, so the for loop below
+        // with both filter lists concat'ed can index properly
+        var denseDisabledFilters = Array.from(filters, (_, index) =>
+          Boolean(disabledFilters[index])
+        )
+        var denseDisabledGlobalFilters = Array.from(globalFilters, (_, index) =>
+          Boolean(disabledGlobalFilters[index])
+        )
+
+        var allDisabledFilters = denseDisabledFilters.concat(
+          denseDisabledGlobalFilters
+        )
 
         // we observe this dimensions filter
         for (var i = 0; i < allFilters.length; i++) {
@@ -1850,7 +1867,20 @@ export function replaceRelative(sqlStr) {
           var filterQuery = ""
           var nonNullFilterCount = 0
           var allFilters = filters.concat(globalFilters)
-          var allDisabledFilters = disabledFilters.concat(disabledGlobalFilters)
+
+          // Fill in dense arrays to match the filter list, so the for loop below
+          // with both filter lists concat'ed can index properly
+          var denseDisabledFilters = Array.from(filters, (_, index) =>
+            Boolean(disabledFilters[index])
+          )
+          var denseDisabledGlobalFilters = Array.from(
+            globalFilters,
+            (_, index) => Boolean(disabledGlobalFilters[index])
+          )
+
+          var allDisabledFilters = denseDisabledFilters.concat(
+            denseDisabledGlobalFilters
+          )
 
           // we do not observe this dimensions filter
           for (var i = 0; i < allFilters.length; i++) {
@@ -2774,7 +2804,11 @@ export function replaceRelative(sqlStr) {
 
         if (!ignoreFilters) {
           for (var i = 0; i < globalFilters.length; i++) {
-            if (!disabledGlobalFilters[i] && globalFilters[i] && globalFilters[i] != "") {
+            if (
+              !disabledGlobalFilters[i] &&
+              globalFilters[i] &&
+              globalFilters[i] != ""
+            ) {
               if (validFilterCount > 0) {
                 filterQuery += " AND "
               }


### PR DESCRIPTION
In some cases, disabled filters weren't properly being applied within the writeQuery methods. This was because the disabled filter arrays were sparse - though their indexes matched properly when disabled is true for a filter, if they have empty elements at the end, the `allFilters` concat'ed array that writeQuery loops over won't match the `allDisabledFilters` concat'ed array.

This pads out the disabled arrays first to fix that issue without having to reconfigure the loops.