### PR TITLE
[FE-9262] add enabled flag to toggles

### DIFF
--- a/dist/mapd-crossfilter.js
+++ b/dist/mapd-crossfilter.js
@@ -18249,7 +18249,15 @@ function replaceRelative(sqlStr) {
         var filterQuery = "";
         var nonNullFilterCount = 0;
         var allFilters = filters.concat(globalFilters);
-        var allDisabledFilters = disabledFilters.concat(disabledGlobalFilters);
+
+        var denseDisabledFilters = Array.from(filters, function (_, index) {
+          return Boolean(disabledFilters[index]);
+        });
+        var denseDisabledGlobalFilters = Array.from(globalFilters, function (_, index) {
+          return Boolean(disabledGlobalFilters[index]);
+        });
+
+        var allDisabledFilters = denseDisabledFilters.concat(denseDisabledGlobalFilters);
 
         // we observe this dimensions filter
         for (var i = 0; i < allFilters.length; i++) {
@@ -18504,7 +18512,15 @@ function replaceRelative(sqlStr) {
           var filterQuery = "";
           var nonNullFilterCount = 0;
           var allFilters = filters.concat(globalFilters);
-          var allDisabledFilters = disabledFilters.concat(disabledGlobalFilters);
+
+          var denseDisabledFilters = Array.from(filters, function (_, index) {
+            return Boolean(disabledFilters[index]);
+          });
+          var denseDisabledGlobalFilters = Array.from(globalFilters, function (_, index) {
+            return Boolean(disabledGlobalFilters[index]);
+          });
+
+          var allDisabledFilters = denseDisabledFilters.concat(denseDisabledGlobalFilters);
 
           // we do not observe this dimensions filter
           for (var i = 0; i < allFilters.length; i++) {

--- a/dist/mapd-crossfilter.js
+++ b/dist/mapd-crossfilter.js
@@ -17509,12 +17509,30 @@ function replaceRelative(sqlStr) {
       }
     }
 
-    function toggleFilter(index, enabled) {
-      disabledFilters[index] = enabled === undefined ? !disabledFilters[index] : enabled;
+    // toggleFilter takes a filter index and an optional boolean flag.
+    // if no boolean flag is given, then it flips the state of the filter -
+    // true becomes false, false becomes true.
+    //
+    // if the flag is PRESENT, then it sets the filter to whatever the value of
+    // the flag is, whether it changes it or not.
+    // so toggleFilter(index) will flip the value
+    //    toggleFilter(index, true) will make it true
+    //    toggleFilter(index, false) will make it false
+    function toggleFilter(index, newValue) {
+      disabledFilters[index] = newValue === undefined ? !disabledFilters[index] : newValue;
     }
 
-    function toggleGlobalFilter(index, enabled) {
-      disabledGlobalFilters[index] = enabled === undefined ? !disabledGlobalFilters[index] : enabled;
+    // toggleGlobalFilter takes a filter index and an optional boolean flag.
+    // if no boolean flag is given, then it flips the state of the filter -
+    // true becomes false, false becomes true.
+    //
+    // if the flag is PRESENT, then it sets the filter to whatever the value of
+    // the flag is, whether it changes it or not.
+    // so toggleFilter(index) will flip the value
+    //    toggleFilter(index, true) will make it true
+    //    toggleFilter(index, false) will make it false
+    function toggleGlobalFilter(index, newValue) {
+      disabledGlobalFilters[index] = newValue === undefined ? !disabledGlobalFilters[index] : newValue;
     }
 
     function getFilterString() {
@@ -17588,11 +17606,20 @@ function replaceRelative(sqlStr) {
         return filter;
       }
 
-      function toggleFilter(enabled) {
+      // toggleFilter takes an optional boolean flag.
+      // if no boolean flag is given, then it flips the state of the filter -
+      // true becomes false, false becomes true.
+      //
+      // if the flag is PRESENT, then it sets the filter to whatever the value of
+      // the flag is, whether it changes it or not.
+      // so toggleFilter() will flip the value
+      //    toggleFilter(true) will make it true
+      //    toggleFilter(false) will make it false
+      function toggleFilter(newValue) {
         if (isGlobal) {
-          crossfilter.toggleGlobalFilter(filterIndex, enabled);
+          crossfilter.toggleGlobalFilter(filterIndex, newValue);
         } else {
-          crossfilter.toggleFilter(filterIndex, enabled);
+          crossfilter.toggleFilter(filterIndex, newValue);
         }
       }
 
@@ -17847,11 +17874,20 @@ function replaceRelative(sqlStr) {
         return scopedFilters[dimensionIndex];
       }
 
-      function toggleFilter(enabled) {
+      // toggleFilter takes an optional boolean flag.
+      // if no boolean flag is given, then it flips the state of the filter -
+      // true becomes false, false becomes true.
+      //
+      // if the flag is PRESENT, then it sets the filter to whatever the value of
+      // the flag is, whether it changes it or not.
+      // so toggleFilter() will flip the value
+      //    toggleFilter(true) will make it true
+      //    toggleFilter(false) will make it false
+      function toggleFilter(newValue) {
         if (isGlobal) {
-          crossfilter.toggleGlobalFilter(dimensionIndex, enabled);
+          crossfilter.toggleGlobalFilter(dimensionIndex, newValue);
         } else {
-          crossfilter.toggleFilter(dimensionIndex, enabled);
+          crossfilter.toggleFilter(dimensionIndex, newValue);
         }
       }
 

--- a/dist/mapd-crossfilter.js
+++ b/dist/mapd-crossfilter.js
@@ -17509,12 +17509,12 @@ function replaceRelative(sqlStr) {
       }
     }
 
-    function toggleFilter(index) {
-      disabledFilters[index] = !disabledFilters[index];
+    function toggleFilter(index, enabled) {
+      disabledFilters[index] = enabled === undefined ? !disabledFilters[index] : enabled;
     }
 
-    function toggleGlobalFilter(index) {
-      disabledGlobalFilters[index] = !disabledGlobalFilters[index];
+    function toggleGlobalFilter(index, enabled) {
+      disabledGlobalFilters[index] = enabled === undefined ? !disabledGlobalFilters[index] : enabled;
     }
 
     function getFilterString() {
@@ -17588,11 +17588,11 @@ function replaceRelative(sqlStr) {
         return filter;
       }
 
-      function toggleFilter() {
+      function toggleFilter(enabled) {
         if (isGlobal) {
-          crossfilter.toggleGlobalFilter(filterIndex);
+          crossfilter.toggleGlobalFilter(filterIndex, enabled);
         } else {
-          crossfilter.toggleFilter(filterIndex);
+          crossfilter.toggleFilter(filterIndex, enabled);
         }
       }
 
@@ -17847,11 +17847,11 @@ function replaceRelative(sqlStr) {
         return scopedFilters[dimensionIndex];
       }
 
-      function toggleFilter() {
+      function toggleFilter(enabled) {
         if (isGlobal) {
-          crossfilter.toggleGlobalFilter(dimensionIndex);
+          crossfilter.toggleGlobalFilter(dimensionIndex, enabled);
         } else {
-          crossfilter.toggleFilter(dimensionIndex);
+          crossfilter.toggleFilter(dimensionIndex, enabled);
         }
       }
 
@@ -18250,6 +18250,8 @@ function replaceRelative(sqlStr) {
         var nonNullFilterCount = 0;
         var allFilters = filters.concat(globalFilters);
 
+        // Fill in dense arrays to match the filter list, so the for loop below
+        // with both filter lists concat'ed can index properly
         var denseDisabledFilters = Array.from(filters, function (_, index) {
           return Boolean(disabledFilters[index]);
         });
@@ -18513,6 +18515,8 @@ function replaceRelative(sqlStr) {
           var nonNullFilterCount = 0;
           var allFilters = filters.concat(globalFilters);
 
+          // Fill in dense arrays to match the filter list, so the for loop below
+          // with both filter lists concat'ed can index properly
           var denseDisabledFilters = Array.from(filters, function (_, index) {
             return Boolean(disabledFilters[index]);
           });

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -707,12 +707,30 @@ export function replaceRelative(sqlStr) {
       }
     }
 
-    function toggleFilter(index, enabled) {
-      disabledFilters[index] = enabled === undefined ? !disabledFilters[index] : enabled
+    // toggleFilter takes a filter index and an optional boolean flag.
+    // if no boolean flag is given, then it flips the state of the filter -
+    // true becomes false, false becomes true.
+    //
+    // if the flag is PRESENT, then it sets the filter to whatever the value of
+    // the flag is, whether it changes it or not.
+    // so toggleFilter(index) will flip the value
+    //    toggleFilter(index, true) will make it true
+    //    toggleFilter(index, false) will make it false
+    function toggleFilter(index, newValue) {
+      disabledFilters[index] = newValue === undefined ? !disabledFilters[index] : newValue
     }
 
-    function toggleGlobalFilter(index, enabled) {
-      disabledGlobalFilters[index] = enabled === undefined ? !disabledGlobalFilters[index] : enabled
+    // toggleGlobalFilter takes a filter index and an optional boolean flag.
+    // if no boolean flag is given, then it flips the state of the filter -
+    // true becomes false, false becomes true.
+    //
+    // if the flag is PRESENT, then it sets the filter to whatever the value of
+    // the flag is, whether it changes it or not.
+    // so toggleFilter(index) will flip the value
+    //    toggleFilter(index, true) will make it true
+    //    toggleFilter(index, false) will make it false
+    function toggleGlobalFilter(index, newValue) {
+      disabledGlobalFilters[index] = newValue === undefined ? !disabledGlobalFilters[index] : newValue
     }
 
     function getFilterString(dimIgnoreIndex = -1) {
@@ -793,11 +811,21 @@ export function replaceRelative(sqlStr) {
         return filter
       }
 
-      function toggleFilter(enabled) {
+
+      // toggleFilter takes an optional boolean flag.
+      // if no boolean flag is given, then it flips the state of the filter -
+      // true becomes false, false becomes true.
+      //
+      // if the flag is PRESENT, then it sets the filter to whatever the value of
+      // the flag is, whether it changes it or not.
+      // so toggleFilter() will flip the value
+      //    toggleFilter(true) will make it true
+      //    toggleFilter(false) will make it false
+      function toggleFilter(newValue) {
         if (isGlobal) {
-          crossfilter.toggleGlobalFilter(filterIndex, enabled)
+          crossfilter.toggleGlobalFilter(filterIndex, newValue)
         } else {
-          crossfilter.toggleFilter(filterIndex, enabled)
+          crossfilter.toggleFilter(filterIndex, newValue)
         }
       }
 
@@ -1060,11 +1088,20 @@ export function replaceRelative(sqlStr) {
         return scopedFilters[dimensionIndex]
       }
 
-      function toggleFilter(enabled) {
+      // toggleFilter takes an optional boolean flag.
+      // if no boolean flag is given, then it flips the state of the filter -
+      // true becomes false, false becomes true.
+      //
+      // if the flag is PRESENT, then it sets the filter to whatever the value of
+      // the flag is, whether it changes it or not.
+      // so toggleFilter() will flip the value
+      //    toggleFilter(true) will make it true
+      //    toggleFilter(false) will make it false
+      function toggleFilter(newValue) {
         if (isGlobal) {
-          crossfilter.toggleGlobalFilter(dimensionIndex, enabled)
+          crossfilter.toggleGlobalFilter(dimensionIndex, newValue)
         } else {
-          crossfilter.toggleFilter(dimensionIndex, enabled)
+          crossfilter.toggleFilter(dimensionIndex, newValue)
         }
       }
 

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -720,7 +720,12 @@ export function replaceRelative(sqlStr) {
       var filterString = ""
       var firstElem = true
       filters.forEach(function(value, index) {
-        if (!disabledFilters[index] && value != null && value != "" && index !== dimIgnoreIndex) {
+        if (
+          !disabledFilters[index] &&
+          value != null &&
+          value != "" &&
+          index !== dimIgnoreIndex
+        ) {
           if (!firstElem) {
             filterString += " AND "
           }
@@ -1549,7 +1554,19 @@ export function replaceRelative(sqlStr) {
         var filterQuery = ""
         var nonNullFilterCount = 0
         var allFilters = filters.concat(globalFilters)
-        var allDisabledFilters = disabledFilters.concat(disabledGlobalFilters)
+
+        // Fill in dense arrays to match the filter list, so the for loop below
+        // with both filter lists concat'ed can index properly
+        var denseDisabledFilters = Array.from(filters, (_, index) =>
+          Boolean(disabledFilters[index])
+        )
+        var denseDisabledGlobalFilters = Array.from(globalFilters, (_, index) =>
+          Boolean(disabledGlobalFilters[index])
+        )
+
+        var allDisabledFilters = denseDisabledFilters.concat(
+          denseDisabledGlobalFilters
+        )
 
         // we observe this dimensions filter
         for (var i = 0; i < allFilters.length; i++) {
@@ -1850,7 +1867,20 @@ export function replaceRelative(sqlStr) {
           var filterQuery = ""
           var nonNullFilterCount = 0
           var allFilters = filters.concat(globalFilters)
-          var allDisabledFilters = disabledFilters.concat(disabledGlobalFilters)
+
+          // Fill in dense arrays to match the filter list, so the for loop below
+          // with both filter lists concat'ed can index properly
+          var denseDisabledFilters = Array.from(filters, (_, index) =>
+            Boolean(disabledFilters[index])
+          )
+          var denseDisabledGlobalFilters = Array.from(
+            globalFilters,
+            (_, index) => Boolean(disabledGlobalFilters[index])
+          )
+
+          var allDisabledFilters = denseDisabledFilters.concat(
+            denseDisabledGlobalFilters
+          )
 
           // we do not observe this dimensions filter
           for (var i = 0; i < allFilters.length; i++) {
@@ -2774,7 +2804,11 @@ export function replaceRelative(sqlStr) {
 
         if (!ignoreFilters) {
           for (var i = 0; i < globalFilters.length; i++) {
-            if (!disabledGlobalFilters[i] && globalFilters[i] && globalFilters[i] != "") {
+            if (
+              !disabledGlobalFilters[i] &&
+              globalFilters[i] &&
+              globalFilters[i] != ""
+            ) {
               if (validFilterCount > 0) {
                 filterQuery += " AND "
               }

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -707,12 +707,12 @@ export function replaceRelative(sqlStr) {
       }
     }
 
-    function toggleFilter(index) {
-      disabledFilters[index] = !disabledFilters[index]
+    function toggleFilter(index, enabled) {
+      disabledFilters[index] = enabled === undefined ? !disabledFilters[index] : enabled
     }
 
-    function toggleGlobalFilter(index) {
-      disabledGlobalFilters[index] = !disabledGlobalFilters[index]
+    function toggleGlobalFilter(index, enabled) {
+      disabledGlobalFilters[index] = enabled === undefined ? !disabledGlobalFilters[index] : enabled
     }
 
     function getFilterString(dimIgnoreIndex = -1) {
@@ -793,11 +793,11 @@ export function replaceRelative(sqlStr) {
         return filter
       }
 
-      function toggleFilter() {
+      function toggleFilter(enabled) {
         if (isGlobal) {
-          crossfilter.toggleGlobalFilter(filterIndex)
+          crossfilter.toggleGlobalFilter(filterIndex, enabled)
         } else {
-          crossfilter.toggleFilter(filterIndex)
+          crossfilter.toggleFilter(filterIndex, enabled)
         }
       }
 
@@ -1060,11 +1060,11 @@ export function replaceRelative(sqlStr) {
         return scopedFilters[dimensionIndex]
       }
 
-      function toggleFilter() {
+      function toggleFilter(enabled) {
         if (isGlobal) {
-          crossfilter.toggleGlobalFilter(dimensionIndex)
+          crossfilter.toggleGlobalFilter(dimensionIndex, enabled)
         } else {
-          crossfilter.toggleFilter(dimensionIndex)
+          crossfilter.toggleFilter(dimensionIndex, enabled)
         }
       }
 


### PR DESCRIPTION
So it turns out I *do* need to be able to explicitly set enabled/disabled in toggleFilter - that is, to explicitly toggle it on or off.

This extends the toggle(Global)?Filter method to accept a parameter. If present, it'll set the filter to that flag. If not, it'll toggle it.

crossfilter.toggleFilter() // behaves as before
crossfilter.toggleFilter(true) // explicitly enables the filter
crossfilter.toggleFilter(false) // explicitly disables the filter

A case could be made to have separate on/off methods, but I preferred this approach.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
