### PR TITLE
[FE-9355] smarter timestamp casting

### DIFF
--- a/dist/mapd-crossfilter.js
+++ b/dist/mapd-crossfilter.js
@@ -18600,8 +18600,10 @@ function replaceRelative(sqlStr) {
                     tempBinFilters += " AND ";
                   }
 
+                  var isDateBounds = queryBounds[0] instanceof Date;
+
                   hasBinFilter = true;
-                  tempFilterClause += "(" + dimArray[d] + " >= " + (queryBounds[0] instanceof Date ? formatDateRangeLowerBound(queryBounds[0]) : formatFilterValue(queryBounds[0], true)) + " AND " + dimArray[d] + " <= " + (queryBounds[0] instanceof Date ? formatDateRangeUpperBound(queryBounds[1]) : formatFilterValue(queryBounds[1], true)) + ")";
+                  tempFilterClause += "(" + dimArray[d] + " >= " + (isDateBounds ? formatDateRangeLowerBound(queryBounds[0]) : formatFilterValue(queryBounds[0], true)) + " AND " + dimArray[d] + (isDateBounds ? " < " : " <= ") + (isDateBounds ? formatDateRangeUpperBound(queryBounds[1]) : formatFilterValue(queryBounds[1], true)) + ")";
                   if (!eliminateNull) {
                     tempFilterClause = "(" + tempFilterClause + " OR (" + dimArray[d] + " IS NULL))";
                   }

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -712,7 +712,8 @@ export function replaceRelative(sqlStr) {
     //    toggleFilter(index, true) will make it true
     //    toggleFilter(index, false) will make it false
     function toggleFilter(index, newValue) {
-      disabledFilters[index] = newValue === undefined ? !disabledFilters[index] : newValue
+      disabledFilters[index] =
+        newValue === undefined ? !disabledFilters[index] : newValue
     }
 
     // toggleGlobalFilter takes a filter index and an optional boolean flag.
@@ -725,7 +726,8 @@ export function replaceRelative(sqlStr) {
     //    toggleFilter(index, true) will make it true
     //    toggleFilter(index, false) will make it false
     function toggleGlobalFilter(index, newValue) {
-      disabledGlobalFilters[index] = newValue === undefined ? !disabledGlobalFilters[index] : newValue
+      disabledGlobalFilters[index] =
+        newValue === undefined ? !disabledGlobalFilters[index] : newValue
     }
 
     function getFilterString(dimIgnoreIndex = -1) {
@@ -805,7 +807,6 @@ export function replaceRelative(sqlStr) {
         }
         return filter
       }
-
 
       // toggleFilter takes an optional boolean flag.
       // if no boolean flag is given, then it flips the state of the filter -

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -237,17 +237,18 @@ function formatDateRangeLowerBound(value) {
       .toISOString()
       .slice(0, -1)
       .replace("T", " ") +
-    "000000'"
+    "'"
   )
 }
 function formatDateRangeUpperBound(value) {
   return (
     "'" +
-    value
+    // Advance the time by one ms to get the upper bound
+    new Date(value.getTime() + 1)
       .toISOString()
       .slice(0, -1)
       .replace("T", " ") +
-    "999999'"
+    "'"
   )
 }
 
@@ -1146,7 +1147,7 @@ export function replaceRelative(sqlStr) {
               const max = formatDateRangeUpperBound(typedValue[1])
               const dimension = dimArray[e]
               subExpression +=
-                dimension + " >= " + min + " AND " + dimension + " <= " + max
+                dimension + " >= " + min + " AND " + dimension + " < " + max
             } else {
               const min = typedValue[0]
               const max = typedValue[1]
@@ -1289,16 +1290,17 @@ export function replaceRelative(sqlStr) {
             subExpression += " AND "
           }
 
-          var typedRange =
-            range[e][0] instanceof Date
-              ? [
-                  formatDateRangeLowerBound(range[e][0]),
-                  formatDateRangeUpperBound(range[e][1])
-                ]
-              : [
-                  formatFilterValue(range[e][0], true),
-                  formatFilterValue(range[e][1], true)
-                ]
+          const rangeIsDate = range[e][0] instanceof Date
+
+          var typedRange = rangeIsDate
+            ? [
+                formatDateRangeLowerBound(range[e][0]),
+                formatDateRangeUpperBound(range[e][1])
+              ]
+            : [
+                formatFilterValue(range[e][0], true),
+                formatFilterValue(range[e][1], true)
+              ]
 
           if (isRelative) {
             typedRange = [
@@ -1321,7 +1323,7 @@ export function replaceRelative(sqlStr) {
               typedRange[0] +
               " AND " +
               dimension +
-              " <= " +
+              (rangeIsDate ? " < " : " <= ") +
               typedRange[1]
           } else {
             subExpression +=
@@ -1330,7 +1332,7 @@ export function replaceRelative(sqlStr) {
               typedRange[0] +
               " AND " +
               dimArray[e] +
-              " <= " +
+              (rangeIsDate ? " < " : " <= ") +
               typedRange[1]
           }
         }

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -218,7 +218,7 @@ function formatFilterValue(value, wrapInQuotes, isExact) {
     return wrapInQuotes ? "'" + escapedValue + "'" : escapedValue
   } else if (valueType == "date") {
     return (
-      "TIMESTAMP(3) '" +
+      "'" +
       value
         .toISOString()
         .slice(0, -1)
@@ -232,7 +232,7 @@ function formatFilterValue(value, wrapInQuotes, isExact) {
 
 function formatDateRangeLowerBound(value) {
   return (
-    "TIMESTAMP(9) '" +
+    "'" +
     value
       .toISOString()
       .slice(0, -1)
@@ -242,7 +242,7 @@ function formatDateRangeLowerBound(value) {
 }
 function formatDateRangeUpperBound(value) {
   return (
-    "TIMESTAMP(9) '" +
+    "'" +
     value
       .toISOString()
       .slice(0, -1)
@@ -993,9 +993,7 @@ export function replaceRelative(sqlStr) {
         let scopedField =
           isValidTable && isColumnName ? _dimTable + "." + trimmedField : field
 
-        return isDate
-          ? "CAST(" + scopedField + " AS TIMESTAMP(3))"
-          : scopedField
+        return scopedField
       })
 
       var dimensionName = expression.map(function(field) {

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -1957,18 +1957,20 @@ export function replaceRelative(sqlStr) {
                     tempBinFilters += " AND "
                   }
 
+                  const isDateBounds = queryBounds[0] instanceof Date
+
                   hasBinFilter = true
                   tempFilterClause +=
                     "(" +
                     dimArray[d] +
                     " >= " +
-                    (queryBounds[0] instanceof Date
+                    (isDateBounds
                       ? formatDateRangeLowerBound(queryBounds[0])
                       : formatFilterValue(queryBounds[0], true)) +
                     " AND " +
                     dimArray[d] +
-                    " <= " +
-                    (queryBounds[0] instanceof Date
+                    (isDateBounds ? " < " : " <= ") +
+                    (isDateBounds
                       ? formatDateRangeUpperBound(queryBounds[1])
                       : formatFilterValue(queryBounds[1], true)) +
                     ")"

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -1,9 +1,4 @@
-import {
-  checkIfTimeBinInRange,
-  formatDateResult,
-  autoBinParams,
-  unBinResults
-} from "./modules/binning"
+import { unBinResults } from "./modules/binning"
 import { sizeAsyncWithEffects, sizeSyncWithEffects } from "./modules/group"
 import moment from "moment"
 

--- a/test/crossfilter.spec.js
+++ b/test/crossfilter.spec.js
@@ -2897,26 +2897,30 @@ describe("Parse parenthesis() for custom expressions", () => {
   })
 })
 
+// The RegEx /^'[1-2]\d{3}-[0-1]\d-[0-3]\d [0-2]\d:[0-6]\d:[0-6]\d\.\d{3}'$/ matches timestamps of
+// the form "'2019-11-04 00:00:00.000'" (but obviousaly with any date/time)
 describe("replaceRelative", () => {
   it("replaces NOW() with TIMESTAMP", () => {
-    expect(replaceRelative("NOW()")).to.include("TIMESTAMP(3) '")
+    expect(replaceRelative("NOW()")).to.match(
+      /^'[1-2]\d{3}-[0-1]\d-[0-3]\d [0-2]\d:[0-6]\d:[0-6]\d\.\d{3}'$/
+    )
   })
 
   it("replaces 'DATE_ADD(days, 1, NOW())' with TIMESTAMP", () => {
-    expect(replaceRelative("DATE_ADD(days, 1, NOW())")).to.include(
-      "TIMESTAMP(3) '"
+    expect(replaceRelative("DATE_ADD(days, 1, NOW())")).to.match(
+      /^'[1-2]\d{3}-[0-1]\d-[0-3]\d [0-2]\d:[0-6]\d:[0-6]\d\.\d{3}'$/
     )
   })
 
   it("replaces 'DATE_ADD(days, DATEDIFF(days, NOW,  0), NOW())' with TIMESTAMP", () => {
     expect(
       replaceRelative("DATE_ADD(days, DATEDIFF(days, 0, NOW()), NOW())")
-    ).to.include("TIMESTAMP(3) '")
+    ).to.match(/^'[1-2]\d{3}-[0-1]\d-[0-3]\d [0-2]\d:[0-6]\d:[0-6]\d\.\d{3}'$/)
   })
 
   it("replaces 'DATE_ADD(days, DATEDIFF(days, NOW,  0)-2, NOW())' with TIMESTAMP", () => {
     expect(
       replaceRelative("DATE_ADD(days, DATEDIFF(days, 0, NOW())-2, NOW())")
-    ).to.include("TIMESTAMP(3) '")
+    ).to.match(/^'[1-2]\d{3}-[0-1]\d-[0-3]\d [0-2]\d:[0-6]\d:[0-6]\d\.\d{3}'$/)
   })
 })

--- a/test/crossfilter.spec.js
+++ b/test/crossfilter.spec.js
@@ -428,7 +428,7 @@ describe("crossfilter", () => {
         dimension = crossfilter.dimension(["age", "sex", "created_at"])
         dimension.filterExact([50, "f", new Date("2016-01-01")])
         expect(dimension.getFilterString()).to.eq(
-          "age = 50 AND sex = 'f' AND created_at = TIMESTAMP(3) '2016-01-01 00:00:00.000'"
+          "age = 50 AND sex = 'f' AND created_at = '2016-01-01 00:00:00.000'"
         )
       })
       it("uses ANY if dim contains array", function() {
@@ -442,7 +442,7 @@ describe("crossfilter", () => {
             dimension = crsfltr.dimension(["age", "sex", "created_at"])
             dimension.filterExact([50, "f", new Date("2016-01-01")])
             expect(dimension.getFilterString()).to.eq(
-              "50 = ANY tableA.age AND tableA.sex = 'f' AND tableA.created_at = TIMESTAMP(3) '2016-01-01 00:00:00.000'"
+              "50 = ANY tableA.age AND tableA.sex = 'f' AND tableA.created_at = '2016-01-01 00:00:00.000'"
             )
           })
       })
@@ -1479,7 +1479,7 @@ describe("crossfilter", () => {
             .topAsync(20, 20, null)
             .then(result => {
               expect(connector.queryAsync).to.have.been.called.with(
-                "SELECT date_trunc(month, CAST(contributions.contrib_date AS TIMESTAMP(3))) AS key0,date_trunc(month, CAST(contributions.event_date AS TIMESTAMP(3))) AS key1,COUNT(*) AS val FROM contributions WHERE (CAST(contributions.contrib_date AS TIMESTAMP(3)) >= TIMESTAMP(9) '2006-01-01 00:00:00.000000000' AND CAST(contributions.contrib_date AS TIMESTAMP(3)) <= TIMESTAMP(9) '2007-01-01 00:00:00.000999999') AND (CAST(contributions.event_date AS TIMESTAMP(3)) >= TIMESTAMP(9) '2006-01-01 00:00:00.000000000' AND CAST(contributions.event_date AS TIMESTAMP(3)) <= TIMESTAMP(9) '2007-01-01 00:00:00.000999999') GROUP BY key0, key1 ORDER BY val DESC NULLS LAST LIMIT 20 OFFSET 20"
+                "SELECT date_trunc(month, contributions.contrib_date) AS key0,date_trunc(month, contributions.event_date) AS key1,COUNT(*) AS val FROM contributions WHERE (contributions.contrib_date >= '2006-01-01 00:00:00.000' AND contributions.contrib_date < '2007-01-01 00:00:00.001') AND (contributions.event_date >= '2006-01-01 00:00:00.000' AND contributions.event_date < '2007-01-01 00:00:00.001') GROUP BY key0, key1 ORDER BY val DESC NULLS LAST LIMIT 20 OFFSET 20"
               )
             })
         })
@@ -1508,7 +1508,7 @@ describe("crossfilter", () => {
             .topAsync(20, 20, null)
             .then(result => {
               expect(connector.queryAsync).to.have.been.called.with(
-                "SELECT extract(month from contrib_date) AS key0,date_trunc(month, CAST(contributions.event_date AS TIMESTAMP(3))) AS key1,COUNT(*) AS val FROM contributions WHERE (CAST(contributions.event_date AS TIMESTAMP(3)) >= TIMESTAMP(9) '2006-01-01 00:00:00.000000000' AND CAST(contributions.event_date AS TIMESTAMP(3)) <= TIMESTAMP(9) '2007-01-01 00:00:00.000999999') GROUP BY key0, key1 ORDER BY val DESC NULLS LAST LIMIT 20 OFFSET 20"
+                "SELECT extract(month from contributions.contrib_date) AS key0,date_trunc(month, contributions.event_date) AS key1,COUNT(*) AS val FROM contributions WHERE (contributions.event_date >= '2006-01-01 00:00:00.000' AND contributions.event_date < '2007-01-01 00:00:00.001') GROUP BY key0, key1 ORDER BY val DESC NULLS LAST LIMIT 20 OFFSET 20"
               )
             })
         })
@@ -1984,7 +1984,7 @@ describe("crossfilter", () => {
               ])
               .all(() => {
                 expect(connector.queryAsync).to.have.been.called.with(
-                  "SELECT date_trunc(month, CAST(contributions.contrib_date AS TIMESTAMP(3))) AS key0,COUNT(*) AS val FROM contributions WHERE (CAST(contributions.contrib_date AS TIMESTAMP(3)) >= TIMESTAMP(9) '2006-01-01 00:00:00.000000000' AND CAST(contributions.contrib_date AS TIMESTAMP(3)) <= TIMESTAMP(9) '2007-01-01 00:00:00.000999999') GROUP BY key0 ORDER BY key0"
+                  "SELECT date_trunc(month, contributions.contrib_date) AS key0,COUNT(*) AS val FROM contributions WHERE (contributions.contrib_date >= '2006-01-01 00:00:00.000' AND contributions.contrib_date < '2007-01-01 00:00:00.001') GROUP BY key0 ORDER BY key0"
                 )
               })
           })
@@ -2004,7 +2004,7 @@ describe("crossfilter", () => {
               ])
               .all(() => {
                 expect(connector.queryAsync).to.have.been.called.with(
-                  "SELECT extract(month from contrib_date) AS key0,COUNT(*) AS val FROM contributions GROUP BY key0 ORDER BY key0"
+                  "SELECT extract(month from contributions.contrib_date) AS key0,COUNT(*) AS val FROM contributions GROUP BY key0 ORDER BY key0"
                 )
               })
           })


### PR DESCRIPTION
### :speech_balloon: Description

Per discussion from @wamsiv, timestamp casts (specifically for combo chart range bounds) are now redundant; the Core should automatically cast as appropriate. According  to Todd, these `CAST`s are significantly hurting query performance. So I'm removing that `CAST` from SQL generation.

Note: I also changed the upper range calculation for time ranges. Previously, we took the ms-precision timestamp (so, seconds + three decimal points of ms precision) and appended the string `999999` (for nanosecond precision), and used `<= upperBound`. Now, I take the ms-precision timestamp, add 1ms, and use `< upperBound`.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Author referenced issue(s) fixed by this PR:
- [x] Fixes FE-9355

## :smoking: Smoke Test
- [x] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.
