### PR TITLE
Add OR _ IS NULL when adding non-null inverse equality filters, to avoid filtering nulls out too

### DIFF
--- a/test/crossfilter.spec.js
+++ b/test/crossfilter.spec.js
@@ -583,7 +583,7 @@ describe("crossfilter", () => {
         dimension.setDrillDownFilter("drilldown is true")
         expect(dimension.filterMulti([1, 2], null, true)).to.eql(dimension)
         expect(dimension.getFilterString()).to.eq(
-          "(NOT (bargle = 1) AND NOT (bargle = 2))"
+          "((NOT (bargle = 1) OR bargle IS NULL) AND (NOT (bargle = 2) OR bargle IS NULL))"
         )
       })
       it("OR concats if drillDownFilter not set", () => {


### PR DESCRIPTION
This adds `OR col IS NULL` when an inverse exact filter (like `NOT (col = 'value')`) is added to a dimension. This is meant to make the behavior more intuitive and 'correct' to users who probably don't expect the SQL behavior of not including nulls when an inverse equality filter is acting on a non-null value.

Before this change:
`NOT (color = 'cerulean')`
```
puce            puce
ochre     ->    ochre
cerulean        fuchsia
fuchsia
NULL
```

After this change:
`NOT (color = 'cerulean') OR color IS NULL`
```
puce            puce
ochre     ->    ochre
cerulean        fuchsia
fuchsia         NULL
NULL
```