### PR TITLE
[FE-10310] - hardwired in 4326 projection

### DIFF
--- a/dist/mapd-crossfilter.js
+++ b/dist/mapd-crossfilter.js
@@ -18153,7 +18153,9 @@ function replaceRelative(sqlStr) {
         var wktString = createWKTPolygonFromPoints(pointsArr); // creating WKT POLYGON from map extent
         if (wktString) {
           var stContainString = "ST_Contains(ST_GeomFromText(";
-          var subExpression = stContainString + "'" + wktString + "'), " + _dimension4.value() + ")";
+          // 4326 is a magic number - omnisci db currently assumes that all projects are 4326. So we hardwire it here.
+          // This will "always" "work" until that constraint changes and we need to dynamically find the projection.
+          var subExpression = stContainString + "'" + wktString + "', 4326), " + _dimension4.value() + ")";
           createSpatialRelAndMeasureQuery(subExpression);
         } else {
           throw new Error("Invalid points array. Must be array of arrays with valid point coordinates");
@@ -18166,7 +18168,9 @@ function replaceRelative(sqlStr) {
         var wktString = createWKTPolygonFromPoints(pointsArr); // creating WKT POLYGON from map extent
         if (wktString) {
           var stContainString = "ST_Intersects(ST_GeomFromText(";
-          var subExpression = stContainString + "'" + wktString + "'), " + _dimension4.value() + ")";
+          // 4326 is a magic number - omnisci db currently assumes that all projects are 4326. So we hardwire it here.
+          // This will "always" "work" until that constraint changes and we need to dynamically find the projection.
+          var subExpression = stContainString + "'" + wktString + "', 4326), " + _dimension4.value() + ")";
           createSpatialRelAndMeasureQuery(subExpression);
         } else {
           throw new Error("Invalid points array. Must be array of arrays with valid point coordinates");
@@ -18180,7 +18184,9 @@ function replaceRelative(sqlStr) {
           var wktString = createWKTPointFromPoint(param.point); // creating WKT POINT from a point array
           if (wktString) {
             var stContainString = "ST_Distance(ST_GeomFromText(";
-            var subExpression = stContainString + "'" + wktString + "'), " + _dimension4.value() + ") <= " + param.distanceInKm / 100;
+            // 4326 is a magic number - omnisci db currently assumes that all projects are 4326. So we hardwire it here.
+            // This will "always" "work" until that constraint changes and we need to dynamically find the projection.
+            var subExpression = stContainString + "'" + wktString + "',4326), " + _dimension4.value() + ") <= " + param.distanceInKm / 100;
             createSpatialRelAndMeasureQuery(subExpression);
           } else {
             throw new Error("Invalid point. Must be array of lon and lat coordinates");

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -1425,7 +1425,9 @@ export function replaceRelative(sqlStr) {
         const wktString = createWKTPolygonFromPoints(pointsArr) // creating WKT POLYGON from map extent
         if (wktString) {
           const stContainString = "ST_Contains(ST_GeomFromText("
-          const subExpression = `${stContainString}'${wktString}'), ${dimension.value()})`
+          // 4326 is a magic number - omnisci db currently assumes that all projects are 4326. So we hardwire it here.
+          // This will "always" "work" until that constraint changes and we need to dynamically find the projection.
+          const subExpression = `${stContainString}'${wktString}', 4326), ${dimension.value()})`
           createSpatialRelAndMeasureQuery(subExpression)
         } else {
           throw new Error(
@@ -1440,7 +1442,9 @@ export function replaceRelative(sqlStr) {
         const wktString = createWKTPolygonFromPoints(pointsArr) // creating WKT POLYGON from map extent
         if (wktString) {
           const stContainString = "ST_Intersects(ST_GeomFromText("
-          const subExpression = `${stContainString}'${wktString}'), ${dimension.value()})`
+          // 4326 is a magic number - omnisci db currently assumes that all projects are 4326. So we hardwire it here.
+          // This will "always" "work" until that constraint changes and we need to dynamically find the projection.
+          const subExpression = `${stContainString}'${wktString}', 4326), ${dimension.value()})`
           createSpatialRelAndMeasureQuery(subExpression)
         } else {
           throw new Error(
@@ -1461,7 +1465,9 @@ export function replaceRelative(sqlStr) {
           const wktString = createWKTPointFromPoint(param.point) // creating WKT POINT from a point array
           if (wktString) {
             const stContainString = "ST_Distance(ST_GeomFromText("
-            const subExpression = `${stContainString}'${wktString}'), ${dimension.value()}) <= ${param.distanceInKm /
+            // 4326 is a magic number - omnisci db currently assumes that all projects are 4326. So we hardwire it here.
+            // This will "always" "work" until that constraint changes and we need to dynamically find the projection.
+            const subExpression = `${stContainString}'${wktString}',4326), ${dimension.value()}) <= ${param.distanceInKm /
               100}`
             createSpatialRelAndMeasureQuery(subExpression)
           } else {


### PR DESCRIPTION
We can't call ST_GeomFromText w/o passing in a projection.

omnisci db DOES allow different projections in geostring columns, but also currently ASSUMES they're all 4326 no matter what. There's also no current way to get the projection on a geocolumn.

So we just assume that it's always 4326 and pass that into ST_GeomFromText(), even though the coordinates had already been translated into 4326 anyway. 

Stops an exception from being thrown for using a differing SRID, even though they're all 4326. AFAICT, that's an old error that's only surface recently since we started reporting the exception instead of letting it die on the console.